### PR TITLE
add support to Lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ end)
 - Restart neovim to reload config
 - Call `:PackerSync`
 
+### lazy.nvim
+```lua
+return {
+  'kaarmu/typst.vim',
+  ft = 'typ',
+  lazy=false,
+}
+```
+
 ### vim-plug
 
 ```vim


### PR DESCRIPTION
`lazy.nvim` use `opt` like directory by default not `start` to turn off we need to make `lazy=false`
```lua
return {
  'kaarmu/typst.vim',
  ft = 'typ',
  lazy=false,
}

```