### PR TITLE
Adding the TypstWatch command

### DIFF
--- a/ftplugin/typst.vim
+++ b/ftplugin/typst.vim
@@ -20,7 +20,8 @@ setlocal formatoptions+=croq
 setlocal suffixesadd=.typ
 
 " FIXME: quick hack for #11
-function! TypstWatch() abort
+" this will introduce the jobstart/job_start problem with neovim/vim
+function! TypstWatch()
     " Prepare command
     let l:cmd = 'typst watch % --open'
     let l:str = has('win32')
@@ -28,7 +29,11 @@ function! TypstWatch() abort
           \ : ['sh', '-c', l:cmd]
 
     " Execute command and toggle status
-    call job_start(expand(l:str))
+    if has('nvim')
+        let s:watcher = jobstart(expand(l:str))
+    else
+        let s:watcher = job_start(expand(l:str))
+    endif
 endfunction
 command! -buffer TypstWatch call TypstWatch()
 

--- a/ftplugin/typst.vim
+++ b/ftplugin/typst.vim
@@ -26,7 +26,7 @@ function! TypstWatch()
     let l:cmd = 'typst watch % --open'
     let l:str = has('win32')
           \ ? 'cmd /s /c "' . l:cmd . '"'
-          \ : ['sh', '-c', l:cmd]
+          \ : 'sh -c "' . l:cmd . '"'
 
     " Execute command and toggle status
     if has('nvim')

--- a/ftplugin/typst.vim
+++ b/ftplugin/typst.vim
@@ -23,16 +23,16 @@ setlocal suffixesadd=.typ
 " this will introduce the jobstart/job_start problem with neovim/vim
 function! TypstWatch()
     " Prepare command
-    let l:cmd = 'typst watch % --open'
+    let l:cmd = 'typst watch ' . expand('%') . ' --open'
     let l:str = has('win32')
           \ ? 'cmd /s /c "' . l:cmd . '"'
           \ : 'sh -c "' . l:cmd . '"'
 
     " Execute command and toggle status
     if has('nvim')
-        let s:watcher = jobstart(expand(l:str))
+        let s:watcher = jobstart(l:str)
     else
-        let s:watcher = job_start(expand(l:str))
+        let s:watcher = job_start(l:str)
     endif
 endfunction
 command! -buffer TypstWatch call TypstWatch()

--- a/ftplugin/typst.vim
+++ b/ftplugin/typst.vim
@@ -19,6 +19,19 @@ setlocal formatoptions+=croq
 
 setlocal suffixesadd=.typ
 
+" FIXME: quick hack for #11
+function! TypstWatch() abort
+    " Prepare command
+    let l:cmd = 'typst watch % --open'
+    let l:str = has('win32')
+          \ ? 'cmd /s /c "' . l:cmd . '"'
+          \ : ['sh', '-c', l:cmd]
+
+    " Execute command and toggle status
+    call job_start(expand(l:str))
+endfunction
+command! -buffer TypstWatch call TypstWatch()
+
 let &cpo = s:cpo_orig
 unlet s:cpo_orig
 " vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab


### PR DESCRIPTION
This PR adds the `TypstWatch` command that calls `typst watch % --open` for the file you're currently in. The implementation is far from good for now.  