### PR TITLE
add: spell to markup

### DIFF
--- a/syntax/typst.vim
+++ b/syntax/typst.vim
@@ -8,6 +8,7 @@ if exists("b:current_syntax")
 endif
 
 syntax sync fromstart
+syntax spell toplevel
 
 " Common {{{1
 syntax cluster typstCommon
@@ -213,6 +214,7 @@ syntax region typstHashtagDollar
 " Markup {{{1
 syntax cluster typstMarkup
     \ contains=@typstCommon
+            \ ,@Spell
             \ ,@typstHashtag
             \ ,@typstMarkupText
             \ ,@typstMarkupParens


### PR DESCRIPTION
This PR will enable spell checking in markup mode but won't `set spell` for you. So if you want to have spell checking you must enable spell checking manually. This is something we could change in the future but not everyone wants spell checking so I'll hold off on that until the question resurface.