### PR TITLE
fix highlighting too much as function args

### DIFF
--- a/syntax/typst.vim
+++ b/syntax/typst.vim
@@ -114,7 +114,7 @@ syntax match typstCodeFunction
     \ nextgroup=typstCodeFunctionArgument
 syntax match typstCodeFunctionArgument
     \ contained
-    \ /\v%(.{-}%(\(.{-}\)|\[.{-}\]|\{.{-}\}))*/ transparent
+    \ /\v%(%(\(.{-}\)|\[.{-}\]|\{.{-}\}))*/ transparent
     \ contains=@typstCode
 
 " Code > Parens {{{2


### PR DESCRIPTION
Before:
![grafik](https://github.com/kaarmu/typst.vim/assets/11978847/f4fe42d4-5aa3-486e-80bc-250a2a94d7e5)

After:
![grafik](https://github.com/kaarmu/typst.vim/assets/11978847/a9041154-c907-4c62-8adb-54572e53da0c)

I'm not 100% sure why this fixes it and what might be side effects to this change, always a bit overwhelmed with vim regex