### PR TITLE
add `g:typst_auto_open_quickfix` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ call plug#end()
     see issue [#64](https://github.com/kaarmu/typst.vim/issues/64).
 - `g:typst_auto_close_toc`: 
     Specifies whether TOC will be automatically closed after using it.
+- `g:typst_auto_open_quickfix`:
+    Specifies whether the quickfix list should automatically open when there are errors from typst. Defaults to `v:true`.
 
 ### Commands
 

--- a/autoload/typst.vim
+++ b/autoload/typst.vim
@@ -62,7 +62,9 @@ function! typst#TypstWatcherCb(channel, content, ...)
         endif
     endfor
     call setqflist(l:errors)
-    execute empty(l:errors) ? 'cclose' : 'copen'
+    if g:typst_auto_open_quickfix
+        execute empty(l:errors) ? 'cclose' : 'copen'
+    endif
 endfunction
 
 " Below are adapted from preservim/vim-markdown

--- a/ftplugin/typst.vim
+++ b/ftplugin/typst.vim
@@ -19,6 +19,10 @@ if !exists('g:typst_auto_close_toc')
     let g:typst_auto_close_toc =  0
 endif
 
+if !exists('g:typst_auto_open_quickfix')
+    let g:typst_auto_open_quickfix = 1
+endif
+
 let b:did_ftplugin = 1
 
 let s:cpo_orig = &cpo


### PR DESCRIPTION
As I'm using [typst-lsp](https://github.com/nvarner/typst-lsp) with autosave on `CursorHold` event, the quickfix list popping up was annoying me and felt unnecessary for my usecase. With this option, this functionality can be disabled.