### PR TITLE
Add missing colon in conceal option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ call plug#end()
 - `g:typst_pdf_viewer`:
     Specifies pdf viewer that `typst watch --open` will use.
     *Default:* `''`
-- `gtypst_conceal`:
+- `g:typst_conceal`:
     Enable concealment.
     *Default:* `0`
 - `g:typst_conceal_math`:


### PR DESCRIPTION
This PR adds a missing colon between the `g` and `typst_conceal` option in the README