### PR TITLE
Fixes indentation issue when using delimitMate

### DIFF
--- a/indent/typst.vim
+++ b/indent/typst.vim
@@ -21,16 +21,17 @@ function! TypstIndent(lnum) abort " {{{1
 
     let l:line = getline(a:lnum)
     let l:pline = getline(l:plnum)
+    let ind = indent(l:plnum)
 
     if l:pline =~ '\v[\{\[\(]\s*$'
-      return indent(l:plnum) + s:sw
+      let ind = ind + s:sw
     endif
 
     if l:line =~ '\v[\}\]\)]$'
-      return indent(a:lnum) - s:sw
+      let ind = ind - s:sw
     endif
 
-    return indent(l:plnum)
+    return ind
 endfunction
 " }}}1
 

--- a/indent/typst.vim
+++ b/indent/typst.vim
@@ -27,7 +27,7 @@ function! TypstIndent(lnum) abort " {{{1
       let ind = ind + s:sw
     endif
 
-    if l:line =~ '\v[\}\]\)]$'
+    if l:line =~ '\v^\s*[\}\]\)],*$'
       let ind = ind - s:sw
     endif
 

--- a/indent/typst.vim
+++ b/indent/typst.vim
@@ -21,17 +21,17 @@ function! TypstIndent(lnum) abort " {{{1
 
     let l:line = getline(a:lnum)
     let l:pline = getline(l:plnum)
-    let ind = indent(l:plnum)
+    let l:ind = indent(l:plnum)
 
     if l:pline =~ '\v[\{\[\(]\s*$'
-      let ind = ind + s:sw
+      let l:ind = l:ind + s:sw
     endif
 
     if l:line =~ '\v^\s*[\}\]\)],*$'
-      let ind = ind - s:sw
+      let l:ind = l:ind - s:sw
     endif
 
-    return ind
+    return l:ind
 endfunction
 " }}}1
 


### PR DESCRIPTION
- with delimitMate's expand_cr feature indentation if closing delimiter would be the same as inner line rather than matching the indentation of the opening delimiter
- fixes comment in #49