### PR TITLE
Correct comment indentation and dedent regex

### DIFF
--- a/indent/typst.vim
+++ b/indent/typst.vim
@@ -25,10 +25,10 @@ function! TypstIndent(lnum) abort " {{{1
     let l:line = getline(a:lnum)
     let l:ind = indent(l:plnum)
 
-    let l:stack = [''] + map(synstack(v:lnum, 1), "synIDattr(v:val, 'name')")
+    let l:synname = synIDattr(synID(a:lnum, 1, 1), "name")
 
     " Use last indent for block comments
-    if l:stack[-1] == 'typstCommentBlock'
+    if l:synname == 'typstCommentBlock'
         return l:ind
     endif
 

--- a/indent/typst.vim
+++ b/indent/typst.vim
@@ -19,27 +19,13 @@ endfunction
 function! TypstIndent(lnum) abort " {{{1
     let s:sw = shiftwidth()
 
-    let l:plnum = prevnonblank(a:lnum - 1)
-    if l:plnum == 0 
-        return 0 
-    endif
-
-    let l:pline = getline(l:plnum)
-
-    " Skip comment lines
-    while l:pline =~ '\v//.*$'
-        let l:plnum = prevnonblank(l:plnum - 1)
-        if l:plnum == 0 
-            return 0 
-        endif
-
-        let l:pline = getline(l:plnum)
-    endwhile
+    let [l:plnum, l:pline] = s:get_prev_nonblank(a:lnum - 1)
+    if l:plnum == 0 | return 0 | endif
 
     let l:line = getline(a:lnum)
     let l:ind = indent(l:plnum)
 
-    let l:stack = [''] + map(synstack(v:lnum , 1), "synIDattr(v:val, 'name')")
+    let l:stack = [''] + map(synstack(v:lnum, 1), "synIDattr(v:val, 'name')")
 
     " Use last indent for block comments
     if l:stack[-1] == 'typstCommentBlock'
@@ -55,6 +41,26 @@ function! TypstIndent(lnum) abort " {{{1
     endif
 
     return l:ind
+endfunction
+" }}}1
+
+" Gets the previous non-blank line that is not a comment.
+function! s:get_prev_nonblank(lnum) abort " {{{1
+    let l:lnum = prevnonblank(a:lnum)
+    let l:line = getline(l:lnum)
+
+    while l:lnum > 0 && l:line =~ '^\s*//'
+        let l:lnum = prevnonblank(l:lnum - 1)
+        let l:line = getline(l:lnum)
+    endwhile
+
+    return [l:lnum, s:remove_comments(l:line)]
+endfunction
+" }}}1
+
+" Removes comments from the given line.
+function! s:remove_comments(line) abort " {{{1
+    return substitute(a:line, '\s*//.*', '', '')
 endfunction
 " }}}1
 

--- a/indent/typst.vim
+++ b/indent/typst.vim
@@ -8,27 +8,50 @@ let s:cpo_save = &cpoptions
 set cpoptions&vim
 
 setlocal autoindent
-setlocal indentexpr=TypstIndent(v:lnum)
+setlocal indentexpr=TypstIndentExpr()
 " setlocal indentkeys=... " We use the default
+
+" This wrapper function is used to enhance performance.
+function! TypstIndentExpr() abort
+    return TypstIndent(v:lnum)
+endfunction
 
 function! TypstIndent(lnum) abort " {{{1
     let s:sw = shiftwidth()
-    
+
     let l:plnum = prevnonblank(a:lnum - 1)
-    if l:plnum == 0
-	    return 0
+    if l:plnum == 0 
+        return 0 
     endif
+
+    let l:pline = getline(l:plnum)
+
+    " Skip comment lines
+    while l:pline =~ '\v//.*$'
+        let l:plnum = prevnonblank(l:plnum - 1)
+        if l:plnum == 0 
+            return 0 
+        endif
+
+        let l:pline = getline(l:plnum)
+    endwhile
 
     let l:line = getline(a:lnum)
-    let l:pline = getline(l:plnum)
     let l:ind = indent(l:plnum)
 
-    if l:pline =~ '\v[{[(]\s*$'
-      let l:ind = l:ind + s:sw
+    let l:stack = [''] + map(synstack(v:lnum , 1), "synIDattr(v:val, 'name')")
+
+    " Use last indent for block comments
+    if l:stack[-1] == 'typstCommentBlock'
+        return l:ind
     endif
 
-    if l:line =~ '\v^\s*[}\])],*$'
-      let l:ind = l:ind - s:sw
+    if l:pline =~ '\v[{[(]\s*$'
+        let l:ind += s:sw
+    endif
+
+    if l:line =~ '\v^\s*[}\])]'
+        let l:ind -= s:sw
     endif
 
     return l:ind


### PR DESCRIPTION
This PR introduces a wrapper function without arguments for _TypstIndent_ to enhance performance, as recommended in the documentation. Additionally, it ensures that comment lines are properly ignored during indentation computation. And, it addresses a bug related to the dedent regex, ensuring correct behavior even when characters follow `) ] }`.