### PR TITLE
Add space to commentstring

### DIFF
--- a/ftplugin/typst.vim
+++ b/ftplugin/typst.vim
@@ -21,7 +21,7 @@ if g:typst_conceal
     setlocal conceallevel=2
 endif
 
-setlocal commentstring=//%s
+setlocal commentstring=//\ %s
 setlocal comments=s1:/*,mb:*,ex:*/,://
 
 setlocal formatoptions+=croq


### PR DESCRIPTION
From:
```
//comment
```

To:
```
// comment
```

A space between comment marker and text is also used in the typst docs: https://typst.app/docs/reference/syntax/#comments