### PR TITLE
Quickfix window: silent opening.

### DIFF
--- a/autoload/typst.vim
+++ b/autoload/typst.vim
@@ -63,7 +63,7 @@ function! typst#TypstWatcherCb(channel, content, ...)
     endfor
     call setqflist(l:errors)
     if g:typst_auto_open_quickfix
-        execute empty(l:errors) ? 'cclose' : 'copen'
+        execute empty(l:errors) ? 'cclose' : 'copen | wincmd p'
     endif
 endfunction
 


### PR DESCRIPTION
Now the quick fix windows doesn't change the cursor focus, so we can keep working and fixing the mistakes, improves the interoperability with autosave.

Note: Always changing the focus might not be the most efficient solution to this problem.