### PR TITLE
Add support for language aliases in code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,15 @@ call plug#end()
     *Default:* `1`
 - `g:typst_embedded_languages`:
     A list of languages that will be highlighted in code blocks. Typst is always highlighted.
+    If language name is different from the syntax file name, you can use renaming, e.g. `'rs -> rust'`
+    (spaces around the arrow are mandatory).
     *Default:* `[]`
 - `g:typst_folding`:
     Enable folding for typst heading
     *Default:* `0`
 - `g:typst_foldnested`:
     Enable nested foldings
-    *Default:* `1` 
+    *Default:* `1`
 
 ### Commands
 

--- a/syntax/typst-embedded.vim
+++ b/syntax/typst-embedded.vim
@@ -4,21 +4,23 @@
 " Upstream: https://github.com/kaarmu/typst.vim
 
 for s:name in g:typst_embedded_languages
+    let s:langname = substitute(s:name, '  *-> .*$', '', '')
+    let s:langfile = substitute(s:name, '^.* ->  *', '', '')
     let s:include = ['syntax include'
-                \   ,'@typstEmbedded_'..s:name
-                \   ,'syntax/'..s:name..'.vim']
+                \   ,'@typstEmbedded_'..s:langname
+                \   ,'syntax/'..s:langfile..'.vim']
     let s:rule = ['syn region'
-                \,s:name
+                \,s:langname
                 \,'matchgroup=Macro'
-                \,'start=/```'..s:name..'\>/ end=/```/' 
-                \,'contains=@typstEmbedded_'..s:name 
+                \,'start=/```'..s:langname..'\>/ end=/```/'
+                \,'contains=@typstEmbedded_'..s:langname
                 \,'keepend']
     if g:typst_conceal
         let s:rule += ['concealends']
-    endif 
+    endif
     execute 'silent! ' .. join(s:include, ' ')
     unlet! b:current_syntax
     execute join(s:rule, ' ')
 endfor
 
-" vim: sw=4 sts=4 et fdm=marker fdl=0 
+" vim: sw=4 sts=4 et fdm=marker fdl=0


### PR DESCRIPTION
I suggest to add support for code blocks to use an alias name. For example,
````typ
```rs
```
````

and

````typ
```rust
```
````

should behave the same, but we have only `rust.vim` syntax file, thus `rs` won't work even being listed in `g:typst_embedded_languages`.

More interestingly, this feature is crutial for some languages: for example, language Idris still uses `idris` as language name, while it has `idris2.vim` syntax file. This PR would enable users to at least use this language in their `g:typst_embedded_languages`.

I made spaces around the optional arrow to be mandatory for guaranteed compatibility: original code was not expecting any languages to contain spaces, to any aliased one wouldn't slash with anything.