### PR TITLE
Option to preserve shiftwidth

### DIFF
--- a/ftplugin/typst.vim
+++ b/ftplugin/typst.vim
@@ -15,7 +15,9 @@ compiler typst
 setlocal expandtab
 setlocal tabstop=8
 setlocal softtabstop=2
-setlocal shiftwidth=2
+if !g:typst_preserve_shiftwidth
+    setlocal shiftwidth=2
+endif
 
 if g:typst_folding
     setlocal foldexpr=typst#foldexpr()

--- a/ftplugin/typst.vim
+++ b/ftplugin/typst.vim
@@ -12,10 +12,10 @@ compiler typst
 " " If you're on typst <v0.8, workaround for https://github.com/typst/typst/issues/1937
 " set errorformat^=\/%f:%l:%c:%m
 
-setlocal expandtab
-setlocal tabstop=8
-setlocal softtabstop=2
-if !g:typst_preserve_shiftwidth
+if !exists("g:typst_recommended_style") || g:typst_recommended_style != 0
+    setlocal expandtab
+    setlocal tabstop=8
+    setlocal softtabstop=2
     setlocal shiftwidth=2
 endif
 


### PR DESCRIPTION
Add the option to preserve `shiftwidth` set elsewhere using global `g:typst_preserve_shiftwidth` for users like myself who prefer a non-2 shiftwidth