### PR TITLE
fix typst_folding config option setting uninitialized value

### DIFF
--- a/ftplugin/typst.vim
+++ b/ftplugin/typst.vim
@@ -20,6 +20,9 @@ setlocal shiftwidth=2
 if g:typst_folding
     setlocal foldexpr=typst#foldexpr()
     setlocal foldmethod=expr
+    if !exists("b:undo_ftplugin")
+        let b:undo_ftplugin = ""
+    endif
     let b:undo_ftplugin .= "|setl foldexpr< foldmethod<"
 endif
 


### PR DESCRIPTION
When i attempted to enable the typst_folding, i got an error that the value `b:under_ftplugin`  was not yet in scope.
So, i added a check to set the value to empty if it does not yet exist. 
There is certainly a better fix for this issue, and perhaps it could be something wrong with a configuration setting on my end, but figured i'd send the PR just in case it would help.
Thank you!