### PR TITLE
don't shit pdfs next to source

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ call plug#end()
 - `g:typst_pdf_viewer`:
     Specifies pdf viewer that `typst watch --open` will use.
     *Default:* `''`
-- `g:typst_output_dir`:
+- `g:typst_output_to_tmp`:
     Redirect compiled PDFs to `/tmp/typst_out/` followed by the file's path relative to `$HOME`.
     *Default:* `0`
 - `g:typst_conceal`:

--- a/autoload/typst.vim
+++ b/autoload/typst.vim
@@ -10,7 +10,7 @@ function! typst#TypstWatch(...)
         \ . " \"" . expand('%') . "\""
 
     " Add custom output directory if enabled
-    if g:typst_output_dir
+    if g:typst_output_to_tmp
         let l:file_path = expand('%:p')
         let l:home_dir = expand('$HOME')
         " Remove HOME directory prefix if present

--- a/autoload/typst/options.vim
+++ b/autoload/typst/options.vim
@@ -7,7 +7,7 @@ function! typst#options#init() abort " {{{1
     call s:declare_option('typst_syntax_highlight', 1)
     call s:declare_option('typst_cmd', 'typst')
     call s:declare_option('typst_pdf_viewer', '')
-    call s:declare_option('typst_output_dir', 0)
+    call s:declare_option('typst_output_to_tmp', 0)
     call s:declare_option('typst_conceal', 0)
     call s:declare_option('typst_conceal_math', g:typst_conceal)
     call s:declare_option('typst_conceal_emoji', g:typst_conceal)


### PR DESCRIPTION
basic implementation of an optional flag to redirect directory where pdfs are created

when working on coherent projects with multiple typst files, appearance of pdfs in the source every time you open them, often makes life miserable. Simple solution to solve that.

can be enabled with:
```lua
vim.g.typst_output_dir = true
```
which then redirects pdfs to `/tmp/typst_out/$file_path_from_home`

// can extend functionality if you want it to be more configurable